### PR TITLE
fixed the 'java didn't find common..etc' issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,27 +15,16 @@
  */
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '1.11'
+    gradleVersion = '2.2.1'
 }
 
 buildscript {
-    def rosMavenPath = "$System.env.ROS_MAVEN_PATH".split(':').collect { 'file://' + it }
-    def rosMavenRepository = "$System.env.ROS_MAVEN_REPOSITORY"
-    repositories {
-        rosMavenPath.each { p ->
-            maven {
-                url p
-            }
-        }
-        mavenLocal()
-        maven {
-            url rosMavenRepository
-        }
-    }
-    dependencies {
-        classpath group: 'org.ros.rosjava_bootstrap', name: 'gradle_plugins', version: '[0.1,0.2)'
-    }
+  apply from: "https://github.com/rosjava/rosjava_bootstrap/raw/indigo/buildscript.gradle"
+  dependencies {
+       classpath 'org.codehaus.groovy:groovy-backports-compat23:2.3.5'
+  }
 }
+
 
 apply plugin: 'catkin'
 


### PR DESCRIPTION
Sometimes gradle can't finish since it can't find the dependencies anymore, since the ros_maven_repository changed. Related to this: https://github.com/rosjava/rosjava_core/issues/250
Chaneging the build.gradle file to pull from a different source seems to work. 
It might need further testing but this seem to work for me. 